### PR TITLE
Bump sqlfluff 4.2.2

### DIFF
--- a/docs/description/PG01_postgres.excessive_locks.md
+++ b/docs/description/PG01_postgres.excessive_locks.md
@@ -1,0 +1,43 @@
+# PG01_postgres.excessive_locks
+
+Avoid excessive locks in PostgreSQL DDL statements.
+
+Several PostgreSQL DDL operations acquire locks that block reads or writes
+for the duration of the operation. On large tables this can cause significant
+downtime. This rule flags statements that should use safer alternatives:
+
+* ``CREATE INDEX`` → use ``CONCURRENTLY`` (``CREATE UNIQUE INDEX`` excluded)
+* ``DROP INDEX`` → use ``CONCURRENTLY``
+* ``REINDEX`` → use ``CONCURRENTLY``
+* ``REFRESH MATERIALIZED VIEW`` → use ``CONCURRENTLY``
+
+This rule only applies to the ``postgres`` dialect and is disabled by
+default. Enable it with the ``force_enable = True`` flag.
+
+**Anti-pattern**
+
+DDL that acquires excessive locks.
+
+.. code-block:: sql
+
+    CREATE INDEX idx_foo ON bar (tenant_id);
+
+    DROP INDEX idx_foo;
+
+    REINDEX INDEX idx_foo;
+
+    REFRESH MATERIALIZED VIEW my_view;
+
+**Best practice**
+
+Use non-blocking alternatives.
+
+.. code-block:: sql
+
+    CREATE INDEX CONCURRENTLY idx_foo ON bar (tenant_id);
+
+    DROP INDEX CONCURRENTLY idx_foo;
+
+    REINDEX INDEX CONCURRENTLY idx_foo;
+
+    REFRESH MATERIALIZED VIEW CONCURRENTLY my_view;

--- a/docs/description/PG02_postgres.not_valid_foreign_key.md
+++ b/docs/description/PG02_postgres.not_valid_foreign_key.md
@@ -1,0 +1,32 @@
+# PG02_postgres.not_valid_foreign_key
+
+Create PostgreSQL foreign keys as ``NOT VALID`` before validating.
+
+Adding a foreign key constraint normally validates existing rows as part of
+the ``ALTER TABLE`` statement. On large tables, this can hold locks for
+longer than necessary. Creating the constraint as ``NOT VALID`` defers that
+scan so it can be run later with ``VALIDATE CONSTRAINT``.
+
+This rule only applies to the ``postgres`` dialect and is disabled by
+default. Enable it with the ``force_enable = True`` flag.
+
+**Anti-pattern**
+
+A foreign key constraint that validates existing rows during creation.
+
+.. code-block:: sql
+
+    ALTER TABLE foo ADD CONSTRAINT fk_bar
+        FOREIGN KEY (bar_id) REFERENCES bar (id);
+
+**Best practice**
+
+Create the foreign key as ``NOT VALID``, then validate it in a separate
+statement.
+
+.. code-block:: sql
+
+    ALTER TABLE foo ADD CONSTRAINT fk_bar
+        FOREIGN KEY (bar_id) REFERENCES bar (id) NOT VALID;
+
+    ALTER TABLE foo VALIDATE CONSTRAINT fk_bar;

--- a/docs/description/RF03_references.consistent.md
+++ b/docs/description/RF03_references.consistent.md
@@ -3,7 +3,7 @@
 Column references should be qualified consistently in single table statements.
 
 .. note::
-    For BigQuery, Hive and Redshift this rule is disabled by default.
+    For Athena, BigQuery, Hive and Redshift this rule is disabled by default.
     This is due to historical false positives associated with STRUCT data types.
     This default behaviour may be changed in the future.
     The rule can be enabled with the ``force_enable = True`` flag.

--- a/docs/description/RF07_references.window_alias.md
+++ b/docs/description/RF07_references.window_alias.md
@@ -1,0 +1,38 @@
+# RF07_references.window_alias
+
+Do not reference a column alias inside its own ``OVER`` clause.
+
+Window functions are evaluated before the ``SELECT`` list aliases are
+applied, so an unqualified reference in a ``PARTITION BY`` or ``ORDER BY``
+which happens to match an alias does not resolve to that alias. When more
+than one table is in scope it silently resolves to a real column on one of
+them instead, changing the result without any error.
+
+.. note::
+   This rule is disabled by default. Enable it with the
+   ``force_enable = True`` flag.
+
+**Anti-pattern**
+
+``id`` is an alias for ``t1.col1``, but inside the window it resolves to
+``t2.id`` from the joined table.
+
+.. code-block:: sql
+
+    SELECT
+        t1.col1 AS id,
+        ROW_NUMBER() OVER (PARTITION BY id ORDER BY t1.ts) AS rn
+    FROM t1
+    LEFT JOIN t2 ON t1.col1 = t2.id
+
+**Best practice**
+
+Qualify the reference with its table so the intended column is used.
+
+.. code-block:: sql
+
+    SELECT
+        t1.col1 AS id,
+        ROW_NUMBER() OVER (PARTITION BY t1.col1 ORDER BY t1.ts) AS rn
+    FROM t1
+    LEFT JOIN t2 ON t1.col1 = t2.id

--- a/docs/description/TQ04_tsql.prefer_as_alias.md
+++ b/docs/description/TQ04_tsql.prefer_as_alias.md
@@ -1,0 +1,28 @@
+# TQ04_tsql.prefer_as_alias
+
+Prefer ANSI-style ``AS`` aliasing over ``alias = expression`` in T-SQL.
+
+T-SQL supports an alternative alias form in ``SELECT`` clauses using
+``alias = expression``. This rule enforces the more ANSI-style
+``expression AS alias`` form instead.
+
+This rule only applies to the ``tsql`` dialect and is disabled by
+default. Enable it with the ``force_enable = True`` flag.
+
+**Anti-pattern**
+
+.. code-block:: sql
+   :force:
+
+    SELECT
+        help3 = 'hello',
+        help4 = CASE WHEN help = 'apple' THEN 'hello' END
+
+**Best practice**
+
+.. code-block:: sql
+   :force:
+
+    SELECT
+        'hello' AS help3,
+        CASE WHEN help = 'apple' THEN 'hello' END AS help4

--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -23,7 +23,14 @@
   {
     "patternId": "RF03_references.consistent",
     "title": "Column references should be qualified",
-    "description": "Column references should be qualified consistently in single table statements.\n\n.. note::\n    For BigQuery, Hive and Redshift this rule is disabled by default.\n    This is due to historical false positives associated with STRUCT data types.\n    This default behaviour may be changed in the future.\n    The rule can be enabled with the ``force_enable = True`` flag.\n\n\"consistent\" will be fixed to \"qualified\" if inconsistency is found.\n\n**Anti-pattern**\n\nIn this example, only the reference to ``b`` is qualified.\n\n.. code-block:: sql\n\n    SELECT\n        a,\n        foo.b\n    FROM foo\n\n**Best practice**\n\nEither all column references should be qualified, or all unqualified.\n\n.. code-block:: sql\n\n    SELECT\n        a,\n        b\n    FROM foo\n\n    -- Also good\n\n    SELECT\n        foo.a,\n        foo.b\n    FROM foo",
+    "description": "Column references should be qualified consistently in single table statements.\n\n.. note::\n    For Athena, BigQuery, Hive and Redshift this rule is disabled by default.\n    This is due to historical false positives associated with STRUCT data types.\n    This default behaviour may be changed in the future.\n    The rule can be enabled with the ``force_enable = True`` flag.\n\n\"consistent\" will be fixed to \"qualified\" if inconsistency is found.\n\n**Anti-pattern**\n\nIn this example, only the reference to ``b`` is qualified.\n\n.. code-block:: sql\n\n    SELECT\n        a,\n        foo.b\n    FROM foo\n\n**Best practice**\n\nEither all column references should be qualified, or all unqualified.\n\n.. code-block:: sql\n\n    SELECT\n        a,\n        b\n    FROM foo\n\n    -- Also good\n\n    SELECT\n        foo.a,\n        foo.b\n    FROM foo",
+    "timeToFix": 5,
+    "parameters": []
+  },
+  {
+    "patternId": "RF07_references.window_alias",
+    "title": "Do not reference a column",
+    "description": "Do not reference a column alias inside its own ``OVER`` clause.\n\nWindow functions are evaluated before the ``SELECT`` list aliases are\napplied, so an unqualified reference in a ``PARTITION BY`` or ``ORDER BY``\nwhich happens to match an alias does not resolve to that alias. When more\nthan one table is in scope it silently resolves to a real column on one of\nthem instead, changing the result without any error.\n\n.. note::\n   This rule is disabled by default. Enable it with the\n   ``force_enable = True`` flag.\n\n**Anti-pattern**\n\n``id`` is an alias for ``t1.col1``, but inside the window it resolves to\n``t2.id`` from the joined table.\n\n.. code-block:: sql\n\n    SELECT\n        t1.col1 AS id,\n        ROW_NUMBER() OVER (PARTITION BY id ORDER BY t1.ts) AS rn\n    FROM t1\n    LEFT JOIN t2 ON t1.col1 = t2.id\n\n**Best practice**\n\nQualify the reference with its table so the intended column is used.\n\n.. code-block:: sql\n\n    SELECT\n        t1.col1 AS id,\n        ROW_NUMBER() OVER (PARTITION BY t1.col1 ORDER BY t1.ts) AS rn\n    FROM t1\n    LEFT JOIN t2 ON t1.col1 = t2.id",
     "timeToFix": 5,
     "parameters": []
   },
@@ -164,6 +171,13 @@
     "patternId": "TQ01_tsql.sp_prefix",
     "title": "``sp `` prefix should not be",
     "description": "``SP_`` prefix should not be used for user-defined stored procedures in T-SQL.\n\n**Anti-pattern**\n\nThe ``SP_`` prefix is used to identify system procedures and can adversely\naffect performance of the user-defined stored procedure. It can also break\nsystem procedures if there is a naming conflict.\n\n.. code-block:: sql\n   :force:\n\n    CREATE PROCEDURE dbo.sp_pull_data\n    AS\n    SELECT\n        ID,\n        DataDate,\n        CaseOutput\n    FROM table1\n\n**Best practice**\n\nUse a different name for the stored procedure.\n\n.. code-block:: sql\n   :force:\n\n    CREATE PROCEDURE dbo.pull_data\n    AS\n    SELECT\n        ID,\n        DataDate,\n        CaseOutput\n    FROM table1\n\n    -- Alternatively prefix with USP_ to\n    -- indicate a user-defined stored procedure.\n\n    CREATE PROCEDURE dbo.usp_pull_data\n    AS\n    SELECT\n        ID,\n        DataDate,\n        CaseOutput\n    FROM table1",
+    "timeToFix": 5,
+    "parameters": []
+  },
+  {
+    "patternId": "TQ04_tsql.prefer_as_alias",
+    "title": "Prefer ansi-style ``as`` aliasing over",
+    "description": "Prefer ANSI-style ``AS`` aliasing over ``alias = expression`` in T-SQL.\n\nT-SQL supports an alternative alias form in ``SELECT`` clauses using\n``alias = expression``. This rule enforces the more ANSI-style\n``expression AS alias`` form instead.\n\nThis rule only applies to the ``tsql`` dialect and is disabled by\ndefault. Enable it with the ``force_enable = True`` flag.\n\n**Anti-pattern**\n\n.. code-block:: sql\n   :force:\n\n    SELECT\n        help3 = 'hello',\n        help4 = CASE WHEN help = 'apple' THEN 'hello' END\n\n**Best practice**\n\n.. code-block:: sql\n   :force:\n\n    SELECT\n        'hello' AS help3,\n        CASE WHEN help = 'apple' THEN 'hello' END AS help4",
     "timeToFix": 5,
     "parameters": []
   },
@@ -325,6 +339,20 @@
     "patternId": "AM08_ambiguous.join_condition",
     "title": "Implicit cross join detected",
     "description": "Implicit cross join detected.\n\n**Anti-pattern**\n\nCross joins are valid, but rare in the wild - and more often created by mistake\nthan on purpose. This rule catches situations where a cross join has been specified,\nbut not explicitly and so the risk of a mistaken cross join is highly likely.\n\n.. code-block:: sql\n   :force:\n\n    SELECT\n        foo\n    FROM bar\n    JOIN baz;\n\n**Best practice**\n\nUse CROSS JOIN.\n\n.. code-block:: sql\n   :force:\n\n    SELECT\n        foo\n    FROM bar\n    CROSS JOIN baz;",
+    "timeToFix": 5,
+    "parameters": []
+  },
+  {
+    "patternId": "PG02_postgres.not_valid_foreign_key",
+    "title": "Create postgresql foreign keys as",
+    "description": "Create PostgreSQL foreign keys as ``NOT VALID`` before validating.\n\nAdding a foreign key constraint normally validates existing rows as part of\nthe ``ALTER TABLE`` statement. On large tables, this can hold locks for\nlonger than necessary. Creating the constraint as ``NOT VALID`` defers that\nscan so it can be run later with ``VALIDATE CONSTRAINT``.\n\nThis rule only applies to the ``postgres`` dialect and is disabled by\ndefault. Enable it with the ``force_enable = True`` flag.\n\n**Anti-pattern**\n\nA foreign key constraint that validates existing rows during creation.\n\n.. code-block:: sql\n\n    ALTER TABLE foo ADD CONSTRAINT fk_bar\n        FOREIGN KEY (bar_id) REFERENCES bar (id);\n\n**Best practice**\n\nCreate the foreign key as ``NOT VALID``, then validate it in a separate\nstatement.\n\n.. code-block:: sql\n\n    ALTER TABLE foo ADD CONSTRAINT fk_bar\n        FOREIGN KEY (bar_id) REFERENCES bar (id) NOT VALID;\n\n    ALTER TABLE foo VALIDATE CONSTRAINT fk_bar;",
+    "timeToFix": 5,
+    "parameters": []
+  },
+  {
+    "patternId": "PG01_postgres.excessive_locks",
+    "title": "Avoid excessive locks in postgresql",
+    "description": "Avoid excessive locks in PostgreSQL DDL statements.\n\nSeveral PostgreSQL DDL operations acquire locks that block reads or writes\nfor the duration of the operation. On large tables this can cause significant\ndowntime. This rule flags statements that should use safer alternatives:\n\n* ``CREATE INDEX`` \u2192 use ``CONCURRENTLY`` (``CREATE UNIQUE INDEX`` excluded)\n* ``DROP INDEX`` \u2192 use ``CONCURRENTLY``\n* ``REINDEX`` \u2192 use ``CONCURRENTLY``\n* ``REFRESH MATERIALIZED VIEW`` \u2192 use ``CONCURRENTLY``\n\nThis rule only applies to the ``postgres`` dialect and is disabled by\ndefault. Enable it with the ``force_enable = True`` flag.\n\n**Anti-pattern**\n\nDDL that acquires excessive locks.\n\n.. code-block:: sql\n\n    CREATE INDEX idx_foo ON bar (tenant_id);\n\n    DROP INDEX idx_foo;\n\n    REINDEX INDEX idx_foo;\n\n    REFRESH MATERIALIZED VIEW my_view;\n\n**Best practice**\n\nUse non-blocking alternatives.\n\n.. code-block:: sql\n\n    CREATE INDEX CONCURRENTLY idx_foo ON bar (tenant_id);\n\n    DROP INDEX CONCURRENTLY idx_foo;\n\n    REINDEX INDEX CONCURRENTLY idx_foo;\n\n    REFRESH MATERIALIZED VIEW CONCURRENTLY my_view;",
     "timeToFix": 5,
     "parameters": []
   },

--- a/docs/multiple-tests/all-patterns/patterns.xml
+++ b/docs/multiple-tests/all-patterns/patterns.xml
@@ -6,6 +6,7 @@
     <module name="RF06_references.quoting" />
     <module name="RF02_references.qualification" />
     <module name="RF03_references.consistent" />
+    <module name="RF07_references.window_alias" />
     <module name="RF04_references.keywords" />
     <module name="RF05_references.special_chars" />
     <module name="RF01_references.from" />
@@ -26,6 +27,7 @@
     <module name="LT11_layout.set_operators" />
     <module name="OR01_oracle.empty_batch" />
     <module name="TQ01_tsql.sp_prefix" />
+    <module name="TQ04_tsql.prefer_as_alias" />
     <module name="TQ03_tsql.empty_batch" />
     <module name="TQ02_tsql.procedure_begin_end" />
     <module name="CV09_convention.blocked_words" />
@@ -49,6 +51,8 @@
     <module name="AM06_ambiguous.column_references" />
     <module name="AM09_ambiguous.order_by_limit" />
     <module name="AM08_ambiguous.join_condition" />
+    <module name="PG02_postgres.not_valid_foreign_key" />
+    <module name="PG01_postgres.excessive_locks" />
     <module name="AL10_aliasing.required" />
     <module name="AL04_aliasing.unique.table" />
     <module name="AL05_aliasing.unused" />

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlfluff",
-  "version": "4.1.0",
+  "version": "4.2.2",
   "patterns": [
     {
       "patternId": "JJ01_jinja.padding",
@@ -25,6 +25,13 @@
     },
     {
       "patternId": "RF03_references.consistent",
+      "level": "Error",
+      "category": "ErrorProne",
+      "parameters": [],
+      "enabled": false
+    },
+    {
+      "patternId": "RF07_references.window_alias",
       "level": "Error",
       "category": "ErrorProne",
       "parameters": [],
@@ -165,6 +172,13 @@
     },
     {
       "patternId": "TQ01_tsql.sp_prefix",
+      "level": "Warning",
+      "category": "CodeStyle",
+      "parameters": [],
+      "enabled": false
+    },
+    {
+      "patternId": "TQ04_tsql.prefer_as_alias",
       "level": "Warning",
       "category": "CodeStyle",
       "parameters": [],
@@ -328,6 +342,20 @@
       "patternId": "AM08_ambiguous.join_condition",
       "level": "Error",
       "category": "ErrorProne",
+      "parameters": [],
+      "enabled": false
+    },
+    {
+      "patternId": "PG02_postgres.not_valid_foreign_key",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [],
+      "enabled": false
+    },
+    {
+      "patternId": "PG01_postgres.excessive_locks",
+      "level": "Info",
+      "category": "CodeStyle",
       "parameters": [],
       "enabled": false
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sqlfluff==4.1.0
+sqlfluff==4.2.2
 jsonpickle==4.1.1


### PR DESCRIPTION
## Summary
- Bump `sqlfluff` from `4.1.0` to `4.2.2` (latest release) in `requirements.txt`.
- Regenerate `docs/patterns.json`, `docs/description/description.json`, `docs/description/*.md`, and `docs/multiple-tests/all-patterns/patterns.xml` via `python src/doc-generator.py`.
- No `Dockerfile`/Python base image change needed: sqlfluff 4.2.2 still only requires Python `>=3.10`, and the base image is already `python:3.14-alpine3.23`.

### New rules picked up by the generator
Four new upstream rules appeared since 4.1.0: `PG01_postgres.excessive_locks`, `PG02_postgres.not_valid_foreign_key`, `RF07_references.window_alias`, `TQ04_tsql.prefer_as_alias`. None of their 4-char prefixes (`PG01`, `PG02`, `RF07`, `TQ04`) are in `src/doc-generator.py`'s `enabled_rules` list, so they were generated as `"enabled": false` — consistent with the generator's existing default behavior. Left as-is since enabling by default is a product decision outside the scope of a routine version bump; flagging here in case someone wants to opt them in.

Also picked up an upstream docstring wording change for `RF03` (Athena added to the list of dialects where the rule is disabled by default).

## Test plan
- [x] `pip install -r requirements.txt requests && python src/doc-generator.py` — regenerated docs cleanly, version `4.2.2` written to `docs/patterns.json`.
- [x] `docker build --no-cache -t codacy-sqlfluff:latest .` — builds successfully.
- [x] Smoke-tested the built image with `docker run -it -v $srcDir:/src codacy-sqlfluff:latest`.
- [x] Cloned `codacy/codacy-plugins-test` and ran `sbt "runMain codacy.plugins.DockerTest multiple codacy-sqlfluff:latest"` locally (matches what CI runs): `all-patterns` (4 results) and `with-config-file` (1 result) both passed — `[Success] All tests passed!`.
- [ ] CI checks (to be polled after opening this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)